### PR TITLE
Support multiple bot accounts

### DIFF
--- a/musicleague/bot.py
+++ b/musicleague/bot.py
@@ -34,10 +34,6 @@ def get_botify(bot_id=None):
     return bot_id, Spotify(bot.access_token)
 
 
-def is_bot(user_id):
-    return user_id == get_setting(SPOTIFY_BOT_USERNAME)
-
-
 def create_bot(id, access_token, refresh_token, expires_at):
     if get_bot(id):
         raise BotExistsError('Bot with id %s already exists' % id)

--- a/musicleague/bot.py
+++ b/musicleague/bot.py
@@ -13,8 +13,10 @@ from musicleague.persistence.update import upsert_bot
 from musicleague.spotify import get_spotify_oauth
 
 
-def get_botify():
-    bot_id = get_setting(SPOTIFY_BOT_USERNAME)
+def get_botify(bot_id=None):
+    if bot_id is None:
+        bot_id = get_setting(SPOTIFY_BOT_USERNAME)
+
     bot = select_bot(bot_id)
     if not bot:
         return None, None

--- a/musicleague/routes/auth.py
+++ b/musicleague/routes/auth.py
@@ -136,10 +136,6 @@ def add_bot():
         spotify_user = spotify.current_user()
         bot_id = spotify_user['id']
 
-        # Check that we're adding a bot listed in env var list
-        if not is_bot(bot_id):
-            return 'Invalid bot: %s. If valid, add to environment.' % (bot_id)
-
         app.logger.warn('Create/update bot %s: %s, %s, %s', bot_id,
                         access_token, refresh_token, expires_at)
 

--- a/musicleague/routes/auth.py
+++ b/musicleague/routes/auth.py
@@ -13,7 +13,6 @@ from musicleague.analytics import track_new_user
 from musicleague.analytics import track_user_login
 from musicleague.analytics import track_user_logout
 from musicleague.bot import create_or_update_bot
-from musicleague.bot import is_bot
 from musicleague.persistence.select import select_user
 from musicleague.routes.decorators import login_required
 from musicleague.routes.decorators import templated

--- a/musicleague/spotify.py
+++ b/musicleague/spotify.py
@@ -91,7 +91,12 @@ def update_playlist(submission_period):
     try:
         app.logger.info("Replacing existing tracks with: %s", tracks)
         playlist_id = to_playlist_id(submission_period.playlist_url)
-        playlist = botify.user_playlist(bot_id, playlist_id)
+        playlist = botify.playlist(playlist_id)
+
+        playlist_bot_id = playlist.get('owner').get('id')
+        if playlist_bot_id != bot_id:
+            bot_id, botify = get_botify(bot_id=playlist_bot_id)
+
         botify.user_playlist_replace_tracks(bot_id, playlist_id, tracks)
     except Exception as e:
         app.logger.error("Error updating tracks: %s", json.dumps(tracks))


### PR DESCRIPTION
The original account used for creating Spotify playlists reached the maximum number of playlists allowed for a single Spotify user (10,999). Due to this, we need to expand into a separate account; however, if playlists created with the previous account need to be updated, then we should be able to do that.